### PR TITLE
7 Allow user to specify terminus version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Using this action requires first setting up PHP in the workflow. Huge thanks to 
 
 Please note that the PHP setup action is required __before__ running Terminus setup.
 
+### Variables
+`pantheon-machine-token` (required): This action will not be able to authenticate to panthon unless you pass in your [Pantheon Machine Token](https://pantheon.io/docs/machine-tokens).
+
+`terminus-version` (optional): Due to your project build environment, you may need to remain on an older version of terminus. If so, you can use this variable to do so. Any version format supported by terminus's installer.phar will work. Here is an example:
+
+```yaml
+- name: Installing Terminus
+  uses: chromatichq/setup-pantheon-terminus@master
+  with:
+	pantheon-machine-token: YOUR_TOKEN
+	terminus-version: 2.6.1
+```
+
 ### Workflow Example
 
 The following is a Github Workflow example which will install PHP and Terminus, then output the sites on Pantheon for that account.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Please note that the PHP setup action is required __before__ running Terminus se
 - name: Installing Terminus
   uses: chromatichq/setup-pantheon-terminus@master
   with:
-	pantheon-machine-token: YOUR_TOKEN
-	terminus-version: 2.6.1
+    pantheon-machine-token: YOUR_TOKEN
+    terminus-version: 2.6.1
 ```
 
 ### Workflow Example

--- a/index.js
+++ b/index.js
@@ -11,9 +11,13 @@ const exec = require( '@actions/exec' );
 async function run() {
 	try {
 		const PANTHEON_MACHINE_TOKEN = core.getInput( 'pantheon-machine-token' );
-
+		const TERMINUS_VERSION = core.getInput( 'terminus-version' );
+		const installer_args = [ 'installer.phar', 'install' ];
 		await exec.exec( 'curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar' );
-		await exec.exec( 'sudo php installer.phar install' ); // Sudo is required in order to install bin/terminus.
+		if (TERMINUS_VERSION) {
+		    installer_args.push( '--install-version', `${ TERMINUS_VERSION }` );
+		}
+		await exec.exec( 'sudo php', installer_args ); // Sudo is required in order to install bin/terminus.
 		await exec.exec( 'terminus', [ 'auth:login', `--machine-token=${ PANTHEON_MACHINE_TOKEN }` ] );
 	} catch ( error ) {
 		core.setFailed( error.message );


### PR DESCRIPTION
## Description
This change allows a github workflow to specify which version of terminus to install.

## Motivation / Context
Terminus 3 introduces php changes that are breaking in many legacy environments.

## Testing Instructions / How This Has Been Tested
Create a workflow as follows:

```yaml

name: Setup Terminus

on:
  push:
    branches:
    - master

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@master
    - name: Installing PHP
      uses: shivammathur/setup-php@master
      with:
        php-version: '7.3'
    - name: Installing Terminus
      uses: chromatichq/setup-pantheon-terminus@issue-7-specify-terminus-version
      with:
        pantheon-machine-token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}
        terminus-version: $TERMINUS_VERSION
    - name: Listing Sites
      if: success()
      run: terminus site:list
```
